### PR TITLE
Fix SIGBUS/SIGSEGV with 4G or larger mem

### DIFF
--- a/hw/virtio/virtio-video.c
+++ b/hw/virtio/virtio-video.c
@@ -158,43 +158,19 @@ static size_t virtio_video_process_cmd_stream_drain(VirtIODevice *vdev,
     }
 }
 
-static int virtio_video_get_ramblock_fd(AddressSpace *as,
-                                        hwaddr addr,
-                                        hwaddr *plen,
-                                        bool is_write)
-{
-    hwaddr len = *plen;
-    hwaddr l, xlat;
-    MemoryRegion *mr;
-    struct RAMBlock *rb;
-    FlatView *fv;
-    if (len == 0)
-    {
-        return -1;
-    }
-
-    l = len;
-    RCU_READ_LOCK_GUARD();
-    fv = address_space_to_flatview(as);
-    mr = flatview_translate(fv, addr, &xlat, &l, is_write, MEMTXATTRS_UNSPECIFIED);
-    rb = mr->ram_block;
-
-    DPRINTF("as:%p, addr:%p, mr:%p, ramblock:%p, file:%d\n", as, (void *)addr, mr, mr->ram_block, rb->fd);
-    return rb->fd;
-}
-
 static int virtio_video_resource_create_page(VirtIOVideoResource *resource,
     virtio_video_mem_entry *entries, bool output)
 {
     VirtIOVideoResourceSlice *slice;
     DMADirection dir = output ? DMA_DIRECTION_FROM_DEVICE :
                                 DMA_DIRECTION_TO_DEVICE;
-    hwaddr len;
-    int i, j, n;
-    uint32_t real_size = 0;
-    char *remap_p, *remaped_p;
-    int fd;
+    MemoryRegion *mr;
+    void *base, *fixed, *remapped;
+    hwaddr len, combined_len;
+    ram_addr_t off;
+    int i, j, n, fd;
 
+    combined_len = 0;
     for (i = 0, n = 0; i < resource->num_planes; i++)
     {
         resource->slices[i] = g_new0(VirtIOVideoResourceSlice,
@@ -203,13 +179,12 @@ static int virtio_video_resource_create_page(VirtIOVideoResource *resource,
         for (j = 0; j < resource->num_entries[i]; j++, n++)
         {
             len = entries[n].length;
+            combined_len += len;
             slice = &resource->slices[i][j];
 
             slice->page.base = dma_memory_map(resource->dma_as,
                                               entries[n].addr, &len, dir);
             slice->page.len = len;
-            real_size += len;
-
             if (len < entries[n].length)
             {
                 dma_memory_unmap(resource->dma_as, slice->page.base,
@@ -219,55 +194,42 @@ static int virtio_video_resource_create_page(VirtIOVideoResource *resource,
         }
     }
 
-    if (output)
-    {
-        #ifdef ENABLE_MEMORY_REMAP
-        resource->remapped_base = mmap(NULL, real_size, PROT_READ | PROT_WRITE,
-                                       MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-        #else
-        resource->remapped_base = MAP_FAILED;
-        #endif
+    if (!output)
+        return 0;
 
-        if (resource->remapped_base == MAP_FAILED)
-        {
-            DPRINTF("remap failed, will use slice\n");
-            resource->remapped_base = NULL;
-        }
-        else
-        {
-            resource->remapped_size = real_size;
-            remap_p = resource->remapped_base;
-            for (i = 0, n = 0; i < resource->num_planes; i++)
-            {
-                for (j = 0; j < resource->num_entries[i]; j++, n++)
-                {
-                    len = entries[n].length;
-                    slice = &resource->slices[i][j];
+    #ifdef ENABLE_MEMORY_REMAP
+    base = mmap(NULL, combined_len, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    #else
+    DPRINTF("Resource created, len = %lu\n", combined_len);
+    return 0;
+    #endif
 
-                    fd = virtio_video_get_ramblock_fd(resource->dma_as, entries[n].addr, &len, dir);
-                    if (fd == -1)
-                    {
-                        DPRINTF("remap failed,fd = %d\n", fd);
-                        resource->remapped_base = NULL;
-                        break;
-                    }
-                    remaped_p = (char *)mmap(remap_p, entries[n].length, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_FIXED, fd, entries[n].addr);
-                    if (remaped_p == MAP_FAILED || remaped_p != remap_p)
-                    {
-                        DPRINTF("remap failed, will use slice\n");
-                        resource->remapped_base = NULL;
-                        break;
-                    }
-                    slice->page.remapped_addr = remaped_p;
-                    DPRINTF("entries[n].addr:%p, len:%d, to %p, hint:%p\n", (int *)entries[n].addr, (int)entries[n].length, remaped_p, (char *)remap_p);
-                    remap_p = remaped_p + entries[n].length;
-                }
-            }
+    resource->remapped_base = NULL;
+    resource->remapped_size = 0;
+    if (base == MAP_FAILED)
+        goto failed;
+
+    fixed = base;
+    for (i = 0; i < resource->num_planes; i++) {
+        for (j = 0; j < resource->num_entries[i]; j++)  {
+            mr = memory_region_from_host(resource->slices[i][j].page.base, &off);
+            if (mr == NULL)
+                goto failed;
+            fd = memory_region_get_fd(mr);
+            if (fd == -1)
+                goto failed;
+            remapped = mmap(fixed, resource->slices[i][j].page.len, PROT_READ |
+                            PROT_WRITE, MAP_FIXED | MAP_SHARED, fd, off);
+            if (remapped == MAP_FAILED || remapped != fixed)
+                goto failed;
+
+            fixed += resource->slices[i][j].page.len;
         }
     }
 
-    DPRINTF("Create resource , len = %d\n", real_size);
-
+    resource->remapped_base = base;
+    resource->remapped_size = combined_len;
+    DPRINTF("Resource (remapped) created, len = %lu\n", combined_len);
     return 0;
 
 error:
@@ -280,6 +242,11 @@ error:
         g_free(resource->slices[n]);
     }
     return -1;
+
+failed:
+    DPRINTF("remap failed, will use slice\n");
+    munmap(base, combined_len);
+    return 0;
 }
 
 static size_t virtio_video_process_cmd_resource_create(VirtIODevice *vdev,

--- a/include/hw/virtio/virtio-video.h
+++ b/include/hw/virtio/virtio-video.h
@@ -105,7 +105,6 @@ typedef enum virtio_video_stream_state {
 typedef union VirtIOVideoResourceSlice {
     struct {
         void *base;
-        void *remapped_addr;
         hwaddr len;
     } page;
     struct {
@@ -123,7 +122,7 @@ typedef struct VirtIOVideoResource {
     uint32_t num_entries[VIRTIO_VIDEO_MAX_PLANES];
     VirtIOVideoResourceSlice *slices[VIRTIO_VIDEO_MAX_PLANES];
     void *remapped_base;
-    uint32_t remapped_size;
+    hwaddr remapped_size;
     QLIST_ENTRY(VirtIOVideoResource) next;
 } VirtIOVideoResource;
 


### PR DESCRIPTION
Seems the memory access issue is gone with some adjustment on the method
through which the memory region and fd is fetched. Why the
SIGBUS/SIGSEGV happens is still unclear, but this is fixed anyway.

Signed-off-by: Zhuocheng Ding <zhuocheng.ding@intel.com>